### PR TITLE
[FIX] account_avatax_oca: unbalanced entries error

### DIFF
--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -270,7 +270,9 @@ class AccountMove(models.Model):
                         taxes_to_set.append((index, line_taxes | tax))
                     line.avatax_amt_line = tax_result_line["tax"]
                     #line.avatax_tax_type = tax_result_line["details"][0]["taxSubTypeId"]
-            self.avatax_amount = tax_result["totalTax"]
+            self.with_context(
+                check_move_validity=False
+            ).avatax_amount = tax_result["totalTax"]
             container = {'records': self}
             self.with_context(
                 avatax_invoice=self, check_move_validity=False


### PR DESCRIPTION
Problem: When Avatax recalculates taxes, there is a blocking error due to unbalanced journal items

Steps to Reproduce: 
1. Create a customer invoice with a customer that is not tax exempt
2. Add a line to the invoice (does not need to have a product)
3. Ensure the line includes AVATAX tax, and the fiscal rule is set to the Avatax calculation
4. Save the invoice -- the invoice should have $0 taxes
5. Click on Calculate Tax [with Avatax]
6. Error appears due to unbalanced journal entries

Cause: The code is setting the avatax_amount field, which triggers a recompute of the AR debit line, which triggers a check for unbalanced entries. Since the credit line(s) haven't been updated yet, an error occurs.

Solution: Bypass the balance check when setting the avatax_amount, delay until after all journal items have been adjusted.