### PR TITLE
[FIX][16.0] account_avatax_sale_oca (SO Line Permission Error)

### DIFF
--- a/account_avatax_sale_oca/models/sale_order.py
+++ b/account_avatax_sale_oca/models/sale_order.py
@@ -89,7 +89,7 @@ class SaleOrder(models.Model):
         """
         for order in self:
             order.tax_amount = 0
-            order.order_line.write({"tax_amt": 0})
+            order.order_line.tax_amt = 0
 
     @api.depends("order_line.price_total", "order_line.product_uom_qty", "tax_amount")
     def _compute_amounts(self):


### PR DESCRIPTION
When creating a new SO, there is a access permissions error due to this 'write' in the compute method.